### PR TITLE
feat: 英文、単語登録機能の追加

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -1,4 +1,0 @@
-div {
-  color: red;
-  font-size: 80px;
-}

--- a/app/controllers/meanings_controller.rb
+++ b/app/controllers/meanings_controller.rb
@@ -1,0 +1,40 @@
+class MeaningsController < ApplicationController
+  def create
+    @unknown_word = UnknownWord.find(params[:unknown_word_id])
+    @meaning = @unknown_word.meanings.build(meaning_params)
+    @meaning.unknown_word_id = @unknown_word.id
+    respond_to do |format|
+      if @meaning.save
+        format.turbo_stream do
+          flash.now[:success] = "#{@meaning.content}を登録"
+        end
+      else
+        format.turbo_stream do
+          flash.now[:danger] = "登録できません"
+        end
+      end
+    end
+  end
+
+  def destroy
+    @meaning = Meaning.find(params[:id])
+    respond_to do |format|
+      if @meaning.destroy
+        format.turbo_stream do
+          flash.now[:success] = "#{@meaning.content}を削除しました"
+        end
+      else
+        format.turbo_stream do
+          flash.now[:danger] = "削除できません"
+        end
+      end
+    end
+  end
+
+  private
+
+  def meaning_params
+    params.require(:meaning).permit(:content, :unknown_word_id)
+  end
+end
+

--- a/app/controllers/sentences_controller.rb
+++ b/app/controllers/sentences_controller.rb
@@ -1,0 +1,42 @@
+class SentencesController < ApplicationController
+  def index
+    @sentences = Sentence.all
+  end
+
+  def new
+    @sentence = Sentence.new
+  end
+
+  def create
+    @sentence = Sentence.new(sentence_params)
+    if @sentence.save
+      save_words(@sentence)
+      flash[:success] = "英文を保存しました"
+      redirect_to sentences_path
+    else
+      flash.now[:danger] = "保存できません"
+      render :new
+    end
+  end
+
+  def show
+    sentence = Sentence.find(params[:id])
+    @words = Word.where(sentence_id: sentence.id).order(:position)
+  end
+
+  private
+
+  def sentence_params
+    params.require(:sentence).permit(:content)
+  end
+
+  def save_words(sentence)
+    # 文章を単語ごとに分割
+    words = sentence.content.scan(/[\w'-]+|[.,!?;]/)
+
+    # 単語を順番に保存
+    words.each_with_index do |word, index|
+      Word.create!(sentence_id: sentence.id, content: word, position: index)
+    end
+  end
+end

--- a/app/controllers/unknown_words_controller.rb
+++ b/app/controllers/unknown_words_controller.rb
@@ -1,0 +1,24 @@
+class UnknownWordsController < ApplicationController
+  def index
+    @unknown_words = UnknownWord.all
+    @meaning = Meaning.new
+  end
+
+  def create
+    @unknown_word = UnknownWord.new(word_id: params[:word_id])
+    # if @unknown_word.save
+    #   flash[:success] = "登録！"
+    # end
+    respond_to do |format|
+      if @unknown_word.save
+        format.turbo_stream do
+          flash.now[:success] = "#{@unknown_word.word.content}を登録しました"
+        end
+      else
+        format.turbo_stream do
+          flash.now[:success] = "単語リストに登録できません"
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -1,0 +1,6 @@
+class WordsController < ApplicationController
+  def show
+    sentence = Sentence.find(params[:id])
+    words = Word.where(sentence_id: sentence.id).order(:position)
+  end
+end

--- a/app/helpers/meanings_helper.rb
+++ b/app/helpers/meanings_helper.rb
@@ -1,0 +1,2 @@
+module MeaningsHelper
+end

--- a/app/helpers/sentences_helper.rb
+++ b/app/helpers/sentences_helper.rb
@@ -1,0 +1,2 @@
+module SentencesHelper
+end

--- a/app/helpers/unknown_words_helper.rb
+++ b/app/helpers/unknown_words_helper.rb
@@ -1,0 +1,2 @@
+module UnknownWordsHelper
+end

--- a/app/helpers/words_helper.rb
+++ b/app/helpers/words_helper.rb
@@ -1,0 +1,2 @@
+module WordsHelper
+end

--- a/app/models/meaning.rb
+++ b/app/models/meaning.rb
@@ -1,0 +1,5 @@
+class Meaning < ApplicationRecord
+  belongs_to :unknown_word
+
+  validates :content, length: { maximum: 5 }, presence: true
+end

--- a/app/models/sentence.rb
+++ b/app/models/sentence.rb
@@ -1,0 +1,6 @@
+class Sentence < ApplicationRecord
+  has_many :words
+
+  validates :content, presence: true
+  validates :content, length: { maximum: 2000 }
+end

--- a/app/models/unknown_word.rb
+++ b/app/models/unknown_word.rb
@@ -1,0 +1,4 @@
+class UnknownWord < ApplicationRecord
+  belongs_to :word
+  has_many :meanings
+end

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -1,0 +1,4 @@
+class Word < ApplicationRecord
+  belongs_to :sentence
+  has_many :unknown_words
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,58 @@
   </head>
 
   <body>
+    <%= render "shared/header" %>
+    <div id="error-messages"></div>
     <%= yield %>
   </body>
 </html>
+
+<style>
+  a {
+    text-decoration: none;
+    color: black;
+  }
+  li {
+    list-style: none;
+  }
+</style>
+
+<%# メッセージの表示は全てjsで作れば表示と非表示をはじめから設定できて、ロードがどうとかに左右されないはず。 %>
+<script>
+  function flashMessageTimeOut() {
+  const flashMessage = document.getElementById('flash-message');
+  const replaceFlash = document.getElementById('replace-flash-message');
+  if (flashMessage || replaceFlash) {
+    let timeLeft = 4;
+
+    const countdownInterval = setInterval(function () {
+      timeLeft--;
+      if (timeLeft <= 0) {
+        clearInterval(countdownInterval);
+        if (flashMessage){
+          flashMessage.remove();
+        };
+        if (replaceFlash){
+          replaceFlash.remove();
+        };
+      };
+    }, 1000);
+    if (flashMessage){
+    flashMessage.addEventListener("click", function () {
+      flashMessage.remove();
+    })};
+    if (replaceFlash){
+    replaceFlash.addEventListener("click", function () {
+      replaceFlash.remove();
+    })};
+
+  }
+};
+document.addEventListener("turbo:load", function(){
+  flashMessageTimeOut();
+});
+document.addEventListener("click", function(){
+  flashMessageTimeOut();
+});
+
+</script>

--- a/app/views/meanings/_form.html.erb
+++ b/app/views/meanings/_form.html.erb
@@ -1,0 +1,7 @@
+<div id="meaning-form">
+  <%= form_with model: meaning, url: meanings_path(unknown_word_id: unknown_word.id), data: { turbo_method: :post } do |f| %>
+    <%= f.text_field :content, placeholder: "意味を追加", class: "form-control" %>
+    <%= f.hidden_field :unknown_word_id, value: unknown_word.id %>
+    <%= f.submit "追加", class: "btn btn-primary btn-sm" %>
+  <% end %>
+</div>

--- a/app/views/meanings/create.turbo_stream.erb
+++ b/app/views/meanings/create.turbo_stream.erb
@@ -1,0 +1,33 @@
+<% if @meaning.errors.present? %>
+  <%= turbo_stream.replace "meaning-form" do %>
+    <%= render 'meanings/form', unknown_word: @unknown_word, meaning: @meaning %>
+  <% end %>
+  <%= turbo_stream.append "error-messages-#{@unknown_word.id}" do %>
+    <div class="error-message">1文字以上100文字以内で入力してください</div>
+    <!-- @meaningは全てのフォームに同じものを渡しているため-->
+    <!-- エラーメッセージが一番最初のフォーム上に表示されてしまう。-->
+    <!-- 今回の場合、文字数以外のエラーはないので、turbo_streamで代わりに表示する。-->
+  <% end %>
+<% else %>
+  <%= turbo_stream.append "word-#{@unknown_word.id}" do %>
+     <li>意味: <%= @meaning.content %></li>
+  <% end %>
+  <%= turbo_stream.replace "meaning-form" do %>
+    <%= render 'meanings/form', unknown_word: @unknown_word, meaning: Meaning.new %>
+  <% end %>
+<% end %>
+
+<%= turbo_stream.append "error-messages" do %>
+  <div id="replace-flash-message">
+    <% if flash.now[:success] || flash.now[:danger] %>
+      <div class="alert-label">Wクリックで削除</div>
+      <div class="alert alert-success flash-message">
+        <% if flash.now[:success] %>
+          <%= flash.now[:success] %>
+        <% elsif flash.now[:danger] %>
+          <%= flash.now[:danger] %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/meanings/destroy.turbo_stream.erb
+++ b/app/views/meanings/destroy.turbo_stream.erb
@@ -1,0 +1,16 @@
+<%= turbo_stream.remove "meaning-#{@meaning.id}" %>
+
+<%= turbo_stream.append "error-messages" do %>
+  <div id="replace-flash-message">
+    <% if flash.now[:success] || flash.now[:danger] %>
+      <div class="alert-label">Wクリックで削除</div>
+      <div class="alert alert-success flash-message">
+        <% if flash.now[:success] %>
+          <%= flash.now[:success] %>
+        <% elsif flash.now[:danger] %>
+          <%= flash.now[:danger] %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/sentences/index.html.erb
+++ b/app/views/sentences/index.html.erb
@@ -1,0 +1,9 @@
+<ul>
+  <% @sentences.each do |sentence| %>
+    <li><%= link_to "英文#{sentence.id}", sentence_path(sentence)%></li>
+  <% end %>
+</ul>
+
+<style>
+  
+</style>

--- a/app/views/sentences/new.html.erb
+++ b/app/views/sentences/new.html.erb
@@ -1,0 +1,14 @@
+<%= form_with model: @sentence, local: true do |f| %>
+  <div class="form-group">
+    <%= render "shared/error_messages", object: f.object %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :content, class: "form-label" %>
+    <%= f.text_field :content, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= f.submit "保存", class: "form-control btn btn-outline-primary" %>
+  </div>
+<% end %>

--- a/app/views/sentences/show.html.erb
+++ b/app/views/sentences/show.html.erb
@@ -1,0 +1,24 @@
+<div class="sentence-body">
+  <% @words.each do |word| %>
+    <%= link_to "#{word.content}",unknown_words_path(word_id: word.id), data: { turbo_method: :post }, remote: true, class: "word-content" %>
+  <% end %>
+</div>
+
+<style>
+  .sentence-body {
+    width: 70%;
+    margin: auto;
+    margin-top: 100px;
+    border: solid 2px #ddd;
+    padding: 10px;
+    background: black;
+  }
+  .word-content {
+    margin: 5px 5px;
+    color: #fff;
+    font-weight: bold;
+  }
+  .word-content:hover {
+    color: red;
+  }
+</style>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div class="alert alert-danger">
+    <ul class="mb-0">
+      <% object.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,5 @@
+<header>
+  <%= link_to "英文", sentences_path %>
+  <%= link_to "単語帳", unknown_words_path %>
+  <%= link_to "英文登録", new_sentence_path %>
+</header>

--- a/app/views/unknown_words/create.turbo_stream.erb
+++ b/app/views/unknown_words/create.turbo_stream.erb
@@ -1,0 +1,14 @@
+<%= turbo_stream.append "error-messages" do %>
+  <div id="replace-flash-message">
+    <% if flash.now[:success] || flash.now[:danger] %>
+      <div class="alert-label">Wクリックで削除</div>
+      <div class="alert alert-success flash-message">
+        <% if flash.now[:success] %>
+          <%= flash.now[:success] %>
+        <% elsif flash.now[:danger] %>
+          <%= flash.now[:danger] %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/unknown_words/index.html.erb
+++ b/app/views/unknown_words/index.html.erb
@@ -1,0 +1,29 @@
+<ul>  
+  <% @unknown_words.each do |unknown_word| %>
+    <li>
+      <div class="word-content"><%= unknown_word.word.content %></div>
+     <!-- 意味を追加するフォーム -->
+      <div id="error-messages-<%= unknown_word.id %>"></div>
+      <%= render "meanings/form", unknown_word: unknown_word, meaning: @meaning  %>
+        <!-- 既存の意味リスト -->
+      <ul id="word-<%= unknown_word.id %>">
+        <% unknown_word.meanings.each do |meaning| %>
+          <li id="meaning-<%= meaning.id %>">
+            <%= link_to meaning_path(meaning), data: { turbo_method: :delete } do %>
+              <i class="bi bi-x-circle"></i>
+            <% end %>
+            意味: <%= meaning.content %>
+          </li>
+        <% end %>
+      </ul>
+    </li>
+  <% end %>
+</ul>
+
+<style>
+
+.word-content {
+  font-size: 30px;
+  font-weight: bold;
+}
+</style>

--- a/config/database.yml
+++ b/config/database.yml
@@ -85,8 +85,6 @@ production:
   primary: &primary_production
     <<: *default
     database: engapp_production
-    username: engapp
-    password: <%= ENV["ENGAPP_DATABASE_PASSWORD"] %>
   cache:
     <<: *primary_production
     database: engapp_production_cache

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,7 +2,7 @@ require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-
+  config.hosts << "localhost"
   # Code is not reloaded between requests.
   config.enable_reloading = false
 
@@ -28,7 +28,7 @@ Rails.application.configure do
   config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = false
 
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,8 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
   root "homes#index"
-  # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
-  # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-  # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
-  # Defines the root path route ("/")
-  # root "posts#index"
+  resources :sentences
+  resources :words
+  resources :unknown_words
+  resources :meanings
 end

--- a/db/migrate/20250308063051_create_sentences.rb
+++ b/db/migrate/20250308063051_create_sentences.rb
@@ -1,0 +1,8 @@
+class CreateSentences < ActiveRecord::Migration[8.0]
+  def change
+    create_table :sentences do |t|
+      t.text :content, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250308065330_create_words.rb
+++ b/db/migrate/20250308065330_create_words.rb
@@ -1,0 +1,10 @@
+class CreateWords < ActiveRecord::Migration[8.0]
+  def change
+    create_table :words do |t|
+      t.references :sentence, null: false, foreign_key: true
+      t.text :content, null: false
+      t.integer :position, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250308071430_create_unknown_words.rb
+++ b/db/migrate/20250308071430_create_unknown_words.rb
@@ -1,0 +1,8 @@
+class CreateUnknownWords < ActiveRecord::Migration[8.0]
+  def change
+    create_table :unknown_words do |t|
+      t.references :word, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250309054929_create_meanings.rb
+++ b/db/migrate/20250309054929_create_meanings.rb
@@ -1,0 +1,9 @@
+class CreateMeanings < ActiveRecord::Migration[8.0]
+  def change
+    create_table :meanings do |t|
+      t.references :unknown_word, null: false, foreign_key: true
+      t.text :content, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,41 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 0) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_09_054929) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
+  create_table "meanings", force: :cascade do |t|
+    t.bigint "unknown_word_id", null: false
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["unknown_word_id"], name: "index_meanings_on_unknown_word_id"
+  end
+
+  create_table "sentences", force: :cascade do |t|
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "unknown_words", force: :cascade do |t|
+    t.bigint "word_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["word_id"], name: "index_unknown_words_on_word_id"
+  end
+
+  create_table "words", force: :cascade do |t|
+    t.bigint "sentence_id", null: false
+    t.text "content", null: false
+    t.integer "position", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["sentence_id"], name: "index_words_on_sentence_id"
+  end
+
+  add_foreign_key "meanings", "unknown_words"
+  add_foreign_key "unknown_words", "words"
+  add_foreign_key "words", "sentences"
 end

--- a/test/controllers/meanings_controller_test.rb
+++ b/test/controllers/meanings_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MeaningsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/sentences_controller_test.rb
+++ b/test/controllers/sentences_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SentencesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/unknown_words_controller_test.rb
+++ b/test/controllers/unknown_words_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UnknownWordsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/words_controller_test.rb
+++ b/test/controllers/words_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class WordsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/meanings.yml
+++ b/test/fixtures/meanings.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/sentences.yml
+++ b/test/fixtures/sentences.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/unknown_words.yml
+++ b/test/fixtures/unknown_words.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/words.yml
+++ b/test/fixtures/words.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/meaning_test.rb
+++ b/test/models/meaning_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MeaningTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/sentence_test.rb
+++ b/test/models/sentence_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SentenceTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/unknown_word_test.rb
+++ b/test/models/unknown_word_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UnknownWordTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/word_test.rb
+++ b/test/models/word_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class WordTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 実施内容
### 英文、単語を登録する機能を追加
#### テーブル
- 英文を登録するsentenceテーブルを作成しました
- 英文を単語に分割し保存するwordsテーブルを作成しました
- 分からない単語を保存するunknown-wordsテーブルを作成しました
- 単語の意味を保存するmeaningsテーブルを作成しました

#### 機能
- 英文を登録し、単語に分割して表示できます
- 各単語をクリックすると、単語帳に自動保存されます
- 保存した単語を閲覧でき、それぞれに意味を追加できます